### PR TITLE
(#102) 운동기록 리스트 캘린더 페이지 달력 아래로 이동

### DIFF
--- a/src/app/exercise/_components/exerciseCalendar/exerciseCalendar.tsx
+++ b/src/app/exercise/_components/exerciseCalendar/exerciseCalendar.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useMemo, useRef } from 'react'
+import { useState, useMemo, useRef, forwardRef } from 'react'
 import { startOfMonth, subMonths, addMonths, format } from 'date-fns'
 import { ko } from 'date-fns/locale'
 import { useSpring, animated } from '@react-spring/web'
@@ -17,129 +17,132 @@ type Props = {
   selectedDate: string
 }
 
-export default function ExerciseCalendar({
-  onDateSelect,
-  selectedDate,
-}: Props) {
-  const today = new Date()
-  const [currentMonth, setCurrentMonth] = useState<Date>(startOfMonth(today))
-  const prevMonth = useMemo(() => subMonths(currentMonth, 1), [currentMonth])
-  const nextMonth = useMemo(() => addMonths(currentMonth, 1), [currentMonth])
-  const containerRef = useRef<HTMLDivElement>(null)
-  const [{ x }, api] = useSpring(() => ({ x: 0 }))
+const ExerciseCalendar = forwardRef<HTMLDivElement, Props>(
+  ({ onDateSelect, selectedDate }, ref) => {
+    const today = new Date()
+    const [currentMonth, setCurrentMonth] = useState<Date>(startOfMonth(today))
+    const prevMonth = useMemo(() => subMonths(currentMonth, 1), [currentMonth])
+    const nextMonth = useMemo(() => addMonths(currentMonth, 1), [currentMonth])
+    const containerRef = useRef<HTMLDivElement>(null)
+    const [{ x }, api] = useSpring(() => ({ x: 0 }))
 
-  const bind = useDrag(
-    ({ down, movement: [mx] }) => {
-      if (down) {
-        api.start({ x: mx, immediate: true })
-        return
-      }
+    const bind = useDrag(
+      ({ down, movement: [mx] }) => {
+        if (down) {
+          api.start({ x: mx, immediate: true })
+          return
+        }
 
-      const containerWidth = containerRef.current?.clientWidth || 0
-      const threshold = containerWidth / 4
+        const containerWidth = containerRef.current?.clientWidth || 0
+        const threshold = containerWidth / 4
 
-      if (Math.abs(mx) <= threshold) {
-        api.start({ x: 0 })
-        return
-      }
+        if (Math.abs(mx) <= threshold) {
+          api.start({ x: 0 })
+          return
+        }
 
-      const newMonth = mx > 0 ? prevMonth : nextMonth
-      const isMovingToFuture =
-        newMonth.getTime() > startOfMonth(today).getTime()
-      if (isMovingToFuture) {
-        api.start({ x: 0 })
-        return
-      }
+        const newMonth = mx > 0 ? prevMonth : nextMonth
+        const isMovingToFuture =
+          newMonth.getTime() > startOfMonth(today).getTime()
+        if (isMovingToFuture) {
+          api.start({ x: 0 })
+          return
+        }
 
-      const direction = mx > 0 ? 1 : -1
-      const targetX = direction * containerWidth
+        const direction = mx > 0 ? 1 : -1
+        const targetX = direction * containerWidth
 
-      api.start({
-        x: targetX,
-        config: { tension: 250, friction: 30 },
-        onRest: () => {
-          setCurrentMonth(newMonth)
-        },
-      })
-    },
-    {
-      axis: 'x',
-      filterTaps: true,
-    },
-  )
-  const handlePrev = () => setCurrentMonth(subMonths(currentMonth, 1))
-  const handleNext = () => {
-    if (currentMonth.getTime() >= startOfMonth(today).getTime()) return
-    setCurrentMonth(addMonths(currentMonth, 1))
-  }
+        api.start({
+          x: targetX,
+          config: { tension: 250, friction: 30 },
+          onRest: () => {
+            setCurrentMonth(newMonth)
+          },
+        })
+      },
+      {
+        axis: 'x',
+        filterTaps: true,
+      },
+    )
+    const handlePrev = () => setCurrentMonth(subMonths(currentMonth, 1))
+    const handleNext = () => {
+      if (currentMonth.getTime() >= startOfMonth(today).getTime()) return
+      setCurrentMonth(addMonths(currentMonth, 1))
+    }
 
-  // 애니메이션이 종료되면서 currentMonth 상태가 변경되면, x축을 즉각적으로 맞춰줍니다.
-  useMemo(() => {
-    api.start({ x: 0, immediate: true })
-  }, [currentMonth])
+    // 애니메이션이 종료되면서 currentMonth 상태가 변경되면, x축을 즉각적으로 맞춰줍니다.
+    useMemo(() => {
+      api.start({ x: 0, immediate: true })
+    }, [currentMonth])
 
-  return (
-    <div className={styles['container']}>
-      <div className={styles['header']}>
-        <button onClick={handlePrev} className={styles['nav-button']}>
-          <LeftArrow />
-        </button>
-        <Typography as="span" variant="text15" weight="bold">
-          {format(currentMonth, 'yyyy년 M월', { locale: ko })}
-        </Typography>
-        <button
-          onClick={handleNext}
-          className={styles['nav-button']}
-          disabled={currentMonth.getTime() >= startOfMonth(today).getTime()}
+    return (
+      <div className={styles['container']} ref={ref}>
+        <div className={styles['header']}>
+          <button onClick={handlePrev} className={styles['nav-button']}>
+            <LeftArrow />
+          </button>
+          <Typography as="span" variant="text15" weight="bold">
+            {format(currentMonth, 'yyyy년 M월', { locale: ko })}
+          </Typography>
+          <button
+            onClick={handleNext}
+            className={styles['nav-button']}
+            disabled={currentMonth.getTime() >= startOfMonth(today).getTime()}
+          >
+            <RightArrow />
+          </button>
+        </div>
+
+        <div className={styles['weekdays']}>
+          {['일', '월', '화', '수', '목', '금', '토'].map((weekday) => (
+            <div key={weekday} className={styles['weekday']}>
+              <Typography as="span" variant="text14" weight="bold">
+                {weekday}
+              </Typography>
+            </div>
+          ))}
+        </div>
+
+        <div
+          className={styles['calendar-carousel-container']}
+          ref={containerRef}
+          {...bind()}
         >
-          <RightArrow />
-        </button>
+          <animated.div
+            className={styles['calendar-carousel-view']}
+            style={{
+              transform: x.to(
+                (val) => `translateX(calc(-100% / 3 + ${val}px))`,
+              ),
+            }}
+          >
+            <MonthViewWithData
+              today={today}
+              monthToShow={prevMonth}
+              isActive={false}
+              onDateSelect={onDateSelect}
+              selectedDate={selectedDate}
+            />
+            <MonthViewWithData
+              today={today}
+              monthToShow={currentMonth}
+              isActive={true}
+              onDateSelect={onDateSelect}
+              selectedDate={selectedDate}
+            />
+            <MonthViewWithData
+              today={today}
+              monthToShow={nextMonth}
+              isActive={false}
+              onDateSelect={onDateSelect}
+              selectedDate={selectedDate}
+            />
+          </animated.div>
+        </div>
       </div>
-
-      <div className={styles['weekdays']}>
-        {['일', '월', '화', '수', '목', '금', '토'].map((weekday) => (
-          <div key={weekday} className={styles['weekday']}>
-            <Typography as="span" variant="text14" weight="bold">
-              {weekday}
-            </Typography>
-          </div>
-        ))}
-      </div>
-
-      <div
-        className={styles['calendar-carousel-container']}
-        ref={containerRef}
-        {...bind()}
-      >
-        <animated.div
-          className={styles['calendar-carousel-view']}
-          style={{
-            transform: x.to((val) => `translateX(calc(-100% / 3 + ${val}px))`),
-          }}
-        >
-          <MonthViewWithData
-            today={today}
-            monthToShow={prevMonth}
-            isActive={false}
-            onDateSelect={onDateSelect}
-            selectedDate={selectedDate}
-          />
-          <MonthViewWithData
-            today={today}
-            monthToShow={currentMonth}
-            isActive={true}
-            onDateSelect={onDateSelect}
-            selectedDate={selectedDate}
-          />
-          <MonthViewWithData
-            today={today}
-            monthToShow={nextMonth}
-            isActive={false}
-            onDateSelect={onDateSelect}
-            selectedDate={selectedDate}
-          />
-        </animated.div>
-      </div>
-    </div>
-  )
-}
+    )
+  },
+)
+ExerciseCalendar.displayName = 'ExerciseCalendar'
+export default ExerciseCalendar

--- a/src/app/exercise/_components/exerciseCalendar/monthView.module.css
+++ b/src/app/exercise/_components/exerciseCalendar/monthView.module.css
@@ -32,7 +32,7 @@
   cursor: default;
 }
 
-.today {
+.selected {
   margin: auto;
   width: 38px;
   height: 38px;

--- a/src/app/exercise/_components/exerciseCalendar/monthView.tsx
+++ b/src/app/exercise/_components/exerciseCalendar/monthView.tsx
@@ -67,7 +67,6 @@ const MonthView = memo(function MonthView({
             const dateStr = format(day, 'yyyy-MM-dd')
             const isCurrent = isSameMonth(day, month)
             const isFuture = isAfter(day, today)
-            const isToday = isSameDay(day, today)
             const isSelected = isSameDay(day, parseISO(selectedDate))
             const count = counts[dateStr] ?? 0
 
@@ -83,7 +82,6 @@ const MonthView = memo(function MonthView({
                   styles['cell'],
                   !isCurrent && styles['empty'],
                   isFuture && styles['disabled'],
-                  isToday && styles['today'],
                   isSelected && styles['selected'],
                 )}
                 onClick={() => {

--- a/src/app/exercise/_components/exerciseForm/completeButton.tsx
+++ b/src/app/exercise/_components/exerciseForm/completeButton.tsx
@@ -1,17 +1,19 @@
 import Typography from '@/components/ui/typography'
 import styles from './completeButton.module.css'
 
-const CompleteButton = (
-  <div className={styles['complete-button']}>
-    <Typography
-      as="span"
-      variant="text15"
-      weight="bold"
-      className={styles['complete-button-text']}
-    >
-      완료
-    </Typography>
-  </div>
-)
+const CompleteButton = () => {
+  return (
+    <div className={styles['complete-button']}>
+      <Typography
+        as="span"
+        variant="text15"
+        weight="bold"
+        className={styles['complete-button-text']}
+      >
+        완료
+      </Typography>
+    </div>
+  )
+}
 
 export default CompleteButton

--- a/src/app/exercise/_components/exerciseList/exerciseList.module.css
+++ b/src/app/exercise/_components/exerciseList/exerciseList.module.css
@@ -1,13 +1,11 @@
 .container {
-  height: 400px;
+  min-height: 600px;
   width: calc(100% + 40px);
   margin-left: -20px;
   padding: 0 20px;
   background-color: var(--color-background);
   display: flex;
   flex-direction: column;
-  overflow: auto;
-  scrollbar-width: none;
 }
 .empty-container {
   display: flex;

--- a/src/app/exercise/_components/exercisePoint/scoreBoard.tsx
+++ b/src/app/exercise/_components/exercisePoint/scoreBoard.tsx
@@ -23,7 +23,7 @@ const startDate = format(startOfMonth(new Date()), 'yyyy-MM-dd')
 const endDate = format(new Date(), 'yyyy-MM-dd')
 
 const LEGAL_DOC_URLS = {
-  SCORE_POLICY: '/legal/exercise-score-policy',
+  SCORE_POLICY: 'https://www.undabang.store/legal/exercise-point-policy.html',
 }
 
 const ScoreBoard = () => {

--- a/src/app/exercise/create/page.tsx
+++ b/src/app/exercise/create/page.tsx
@@ -20,7 +20,6 @@ import ExerciseForm, {
   ExerciseFormHandle,
 } from '../_components/exerciseForm/exerciseForm'
 
-
 export default function Create() {
   const [celebration, setCelebration] = useState(false)
   const [createdExerciseId, setCreatedExerciseId] = useState<number | null>(
@@ -89,7 +88,7 @@ export default function Create() {
 
   return (
     <>
-      <Header rightIcon={CompleteButton} onClick={triggerFormSubmit}>
+      <Header rightIcon={<CompleteButton />} onClick={triggerFormSubmit}>
         운동 기록하기
       </Header>
       <ExerciseForm

--- a/src/app/exercise/edit/page.tsx
+++ b/src/app/exercise/edit/page.tsx
@@ -116,7 +116,7 @@ export default function Edit() {
 
   return (
     <>
-      <Header rightIcon={CompleteButton} onClick={triggerFormSubmit}>
+      <Header rightIcon={<CompleteButton />} onClick={triggerFormSubmit}>
         운동 기록 수정
       </Header>
       <ExerciseForm

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -5,7 +5,7 @@ body {
   /* 임시 배경 이미지 */
   background-image: url('/background.svg');
   background-size: 1000px;
-  /* background-attachment: fixed; */
+  background-attachment: fixed;
 }
 
 .responsive-container {


### PR DESCRIPTION
## 📝작업 내용
- 운동기록 리스트 페이지를 메인페이지의 달력 아래로 이동
### 변경전
<img width="520" height="546" alt="image" src="https://github.com/user-attachments/assets/5f23f98e-9f11-4bf4-8fa9-67478b1c674a" />

### 변경후
<img width="272" height="603" alt="image" src="https://github.com/user-attachments/assets/1622a7cd-da61-4f62-88a0-d1dda1946c00" />

- 임시 배경 이미지 추가
- 점수 획득을 못하는 운동은 기록시 축하메세지를 띄워주지 않도록 변경
- 상세기록 페이지에서 각 데이터 필드마다 margin이 적용되지 않던 오류 수정(이전 이슈에서 description을 넣는과정에서 css변경이 원인)
- 운동기록, 운동기록수정 페이지의 완료 버튼을 하단에서 헤더로 이동
<img width="270" height="671" alt="image" src="https://github.com/user-attachments/assets/1f26336d-f72c-4e68-b916-47c0e55de43a" />




## 관련이슈
https://github.com/projects200/front-server/issues/102