### PR TITLE
(#236) 마이페이지 선호운동 선택 Zod & TanStack Form 적용

### DIFF
--- a/src/app/(main)/mypage/prefer-select/_components/detailStep.tsx
+++ b/src/app/(main)/mypage/prefer-select/_components/detailStep.tsx
@@ -24,8 +24,8 @@ const SKILL_LEVELS = [
 
 type Props = {
   myExercises: PreferExercises[]
-  onUpdateDay: (id: number, daysOfWeek: boolean[]) => void
-  onUpdateSkill: (id: number, skillLevel: string) => void
+  onUpdateDay: (exerciseIndex: number, dayIndex: number) => void
+  onUpdateSkill: (exerciseIndex: number, skillLevel: string) => void
 }
 
 export default function DetailStep({
@@ -33,21 +33,10 @@ export default function DetailStep({
   onUpdateDay,
   onUpdateSkill,
 }: Props) {
-  // 요일 토글 헬퍼 함수
-  const handleDayToggle = (
-    exerciseId: number,
-    currentDays: boolean[],
-    dayIndex: number,
-  ) => {
-    const newDays = [...currentDays]
-    newDays[dayIndex] = !newDays[dayIndex]
-    onUpdateDay(exerciseId, newDays)
-  }
-
   return (
     <div className={styles['content']}>
       <div className={styles['list-container']}>
-        {myExercises.map((exercise) => (
+        {myExercises.map((exercise, index) => (
           <div
             key={`card-${exercise.exerciseTypeId}`}
             className={styles['card']}
@@ -81,20 +70,14 @@ export default function DetailStep({
                 운동 주기
               </Typography>
               <div className={styles['day-group']}>
-                {WEEK_DAYS.map((day, index) => (
+                {WEEK_DAYS.map((day, dayIndex) => (
                   <button
-                    key={`${exercise.exerciseTypeId}-day-${index}`}
+                    key={`${exercise.exerciseTypeId}-day-${dayIndex}`}
                     className={clsx(
                       styles['day-chip'],
-                      exercise.daysOfWeek[index] && styles['selected'],
+                      exercise.daysOfWeek[dayIndex] && styles['selected'],
                     )}
-                    onClick={() =>
-                      handleDayToggle(
-                        exercise.exerciseTypeId,
-                        exercise.daysOfWeek,
-                        index,
-                      )
-                    }
+                    onClick={() => onUpdateDay(index, dayIndex)}
                   >
                     <Typography
                       as="span"
@@ -126,9 +109,7 @@ export default function DetailStep({
                       styles['skill-chip'],
                       exercise.skillLevel === level && styles['selected'],
                     )}
-                    onClick={() =>
-                      onUpdateSkill(exercise.exerciseTypeId, level)
-                    }
+                    onClick={() => onUpdateSkill(index, level)}
                   >
                     <Typography
                       as="span"

--- a/src/app/(main)/mypage/prefer-select/_components/selectionStep.tsx
+++ b/src/app/(main)/mypage/prefer-select/_components/selectionStep.tsx
@@ -2,7 +2,7 @@
 
 import clsx from 'clsx'
 
-import { ExerciseItem } from '@/types/mypage'
+import { ExerciseItem, PreferExercises } from '@/types/mypage'
 import CheckIcon from '@/assets/icon_check.svg'
 import Typography from '@/components/ui/typography'
 
@@ -11,8 +11,8 @@ import styles from './selectionStep.module.css'
 type Props = {
   nickName: string
   allExercises: ExerciseItem[]
-  selectedExercises: number[]
-  onToggle: (id: number) => void
+  selectedExercises: PreferExercises[]
+  onToggle: (item: ExerciseItem) => void
 }
 
 export default function SelectionStep({
@@ -32,7 +32,9 @@ export default function SelectionStep({
 
       <div className={styles['list-container']}>
         {allExercises.map((exercise) => {
-          const isSelected = selectedExercises.includes(exercise.exerciseTypeId)
+          const isSelected = selectedExercises.some(
+            (e) => e.exerciseTypeId === exercise.exerciseTypeId,
+          )
 
           return (
             <button
@@ -41,7 +43,7 @@ export default function SelectionStep({
               className={clsx(styles['item'], {
                 [styles['selected']]: isSelected,
               })}
-              onClick={() => onToggle(exercise.exerciseTypeId)}
+              onClick={() => onToggle(exercise)}
             >
               {isSelected && <CheckIcon className={styles['check-icon']} />}
               <Typography as="p" variant="content-medium" weight="bold">

--- a/src/app/(main)/mypage/prefer-select/page.tsx
+++ b/src/app/(main)/mypage/prefer-select/page.tsx
@@ -2,6 +2,8 @@
 
 import { useEffect, useState } from 'react'
 import { useRouter, useSearchParams } from 'next/navigation'
+import * as z from 'zod'
+import { useForm, useStore } from '@tanstack/react-form'
 
 import Header from '@/components/commons/header'
 import CompleteButton from '@/components/commons/completeButton'
@@ -13,6 +15,27 @@ import DetailStep from './_components/detailStep'
 import styles from './preferSelect.module.css'
 
 import { TEMP_DATA, TEMP_MY_DATA } from './tempData'
+
+const preferSelectSchema = z.object({
+  myExercises: z
+    .array(
+      z.object({
+        preferredExerciseId: z.number(),
+        exerciseTypeId: z.number(),
+        name: z.string(),
+        imageUrl: z.string().nullable(),
+        skillLevel: z.string().min(1, '모든 운동의 숙련도를 선택해주세요.'),
+        daysOfWeek: z
+          .array(z.boolean())
+          .refine(
+            (days) => days.some((day) => day),
+            '모든 운동의 주기를 하나 이상 선택해주세요.',
+          ),
+      }),
+    )
+    .min(1, '최소 1개 이상의 운동을 선택해주세요.')
+    .max(5, '최대 5개까지 선택 가능해요.'),
+})
 
 const createNewExercise = (item: ExerciseItem): PreferExercises => ({
   preferredExerciseId: 0,
@@ -31,60 +54,67 @@ export default function PreferSelect() {
 
   const [step, setStep] = useState<'select' | 'detail'>('select')
   const [allExercises, setAllExercises] = useState<ExerciseItem[]>([])
-  const [initialData, setInitialData] = useState<PreferExercises[]>([])
-  const [myExercises, setMyExercises] = useState<PreferExercises[]>([])
+
+  const form = useForm({
+    defaultValues: { myExercises: TEMP_MY_DATA },
+    validators: { onSubmit: preferSelectSchema },
+    canSubmitWhenInvalid: true,
+    onSubmitInvalid: ({ formApi }) => {
+      const fieldErrorMap = formApi.state.errorMap.onSubmit as Record<
+        string,
+        z.ZodIssue[]
+      >
+      const firstIssueArr = Object.values(fieldErrorMap)[0]
+      showToast(firstIssueArr?.[0]?.message ?? '입력값을 확인해주세요.', 'info')
+    },
+    onSubmit: async ({ value }) => {
+      // 백엔드로 데이터 전송 로직 개발 예정
+      console.log('제출 값', value)
+    },
+  })
+
+  const myExercises = useStore(
+    form.baseStore,
+    (state) => state.values.myExercises,
+  )
 
   // 초기 데이터 로드, 백엔드 API 개발 완료시 실제 데이터 호출
   useEffect(() => {
     setAllExercises(TEMP_DATA)
-    setInitialData(TEMP_MY_DATA)
-    setMyExercises(TEMP_MY_DATA)
   }, [])
 
-  // 선호운동 아이템 토글 로직
-  const handleToggleExercise = (id: number) => {
-    const exists = myExercises.find((e) => e.exerciseTypeId === id)
-    if (exists) {
-      setMyExercises((prev) => prev.filter((e) => e.exerciseTypeId !== id))
+  const handleToggleExercise = (exerciseItem: ExerciseItem) => {
+    const existingIndex = myExercises.findIndex(
+      (e) => e.exerciseTypeId === exerciseItem.exerciseTypeId,
+    )
+
+    if (existingIndex > -1) {
+      form.removeFieldValue('myExercises', existingIndex)
     } else {
       if (myExercises.length >= 5) {
         showToast('최대 5개까지 선택 가능해요', 'info')
         return
       }
 
-      const prevData = initialData.find((e) => e.exerciseTypeId === id)
-      const baseInfo = allExercises.find((e) => e.exerciseTypeId === id)
+      const prevData = TEMP_MY_DATA.find(
+        (e) => e.exerciseTypeId === exerciseItem.exerciseTypeId,
+      )
 
-      if (!baseInfo) return
-
-      if (prevData) {
-        setMyExercises((prev) => [...prev, prevData])
-      } else {
-        setMyExercises((prev) => [...prev, createNewExercise(baseInfo)])
-      }
+      form.pushFieldValue(
+        'myExercises',
+        prevData || createNewExercise(exerciseItem),
+      )
     }
   }
 
-  // 요일 업데이트 로직
-  const handleUpdateDay = (exerciseTypeId: number, daysOfWeek: boolean[]) => {
-    setMyExercises((prev) =>
-      prev.map((item) =>
-        item.exerciseTypeId === exerciseTypeId
-          ? { ...item, daysOfWeek: daysOfWeek }
-          : item,
-      ),
-    )
+  const handleUpdateDay = (exerciseIndex: number, dayIndex: number) => {
+    const newDays = [...myExercises[exerciseIndex].daysOfWeek]
+    newDays[dayIndex] = !newDays[dayIndex]
+    form.setFieldValue(`myExercises[${exerciseIndex}].daysOfWeek`, newDays)
   }
 
-  // 숙련도 업데이트 로직
-  const handleUpdateSkill = (exerciseTypeId: number, skillLevel: string) => {
-    setMyExercises((prev) =>
-      prev.map((item) =>
-        item.exerciseTypeId === exerciseTypeId
-          ? { ...item, skillLevel: skillLevel }
-          : item,
-      ),
-    )
+  const handleUpdateSkill = (exerciseIndex: number, skillLevel: string) => {
+    form.setFieldValue(`myExercises[${exerciseIndex}].skillLevel`, skillLevel)
   }
 
   const handleNext = () => {
@@ -96,8 +126,7 @@ export default function PreferSelect() {
   }
 
   const handleComplete = () => {
-    // 백엔드 API 연결 후 제출 로직 작성
-    alert('완료')
+    form.handleSubmit()
   }
 
   return (
@@ -115,7 +144,7 @@ export default function PreferSelect() {
         <SelectionStep
           nickName={nickName}
           allExercises={allExercises}
-          selectedExercises={myExercises.map((e) => e.exerciseTypeId)}
+          selectedExercises={myExercises}
           onToggle={handleToggleExercise}
         />
       ) : (

--- a/src/app/(main)/mypage/prefer-select/tempData.ts
+++ b/src/app/(main)/mypage/prefer-select/tempData.ts
@@ -174,7 +174,7 @@ export const TEMP_MY_DATA = [
     preferredExerciseId: 102,
     exerciseTypeId: 2,
     name: '컬링',
-    imageUrl: null,
+    imageUrl: 'temp/url',
     skillLevel: 'NOVICE',
     daysOfWeek: [false, false, false, false, false, true, true],
   },

--- a/src/components/commons/exerciseImg.module.css
+++ b/src/components/commons/exerciseImg.module.css
@@ -1,4 +1,5 @@
 .exercise-container {
+  position: relative;
   flex-shrink: 0;
   width: 40px;
   height: 40px;

--- a/src/components/commons/exerciseImg.tsx
+++ b/src/components/commons/exerciseImg.tsx
@@ -2,7 +2,7 @@
 
 import Image from 'next/image'
 import clsx from 'clsx'
-import { memo } from 'react'
+import { memo, useEffect, useState } from 'react'
 
 import DefaultExerciseIMage from '@/assets/default_exercise_image.svg'
 
@@ -14,17 +14,26 @@ type Props = {
 }
 
 function ExerciseImg({ className, imageUrl }: Props) {
+  const [imgError, setImgError] = useState(false)
+
+  useEffect(() => {
+    setImgError(false)
+  }, [imageUrl])
+
+  const showDefault = !imageUrl || imgError
+
   return (
-    <div className={clsx(className, styles['exercise-container'])}>
-      {imageUrl ? (
+    <div className={clsx(styles['exercise-container'], className)}>
+      {showDefault ? (
+        <DefaultExerciseIMage className={styles['exercise-img']} />
+      ) : (
         <Image
           className={styles['exercise-img']}
           src={imageUrl}
           alt="운동 이미지"
           fill
+          onError={() => setImgError(true)}
         />
-      ) : (
-        <DefaultExerciseIMage className={styles['exercise-img']} />
       )}
     </div>
   )


### PR DESCRIPTION
## 관련 이슈
(#236)

## 📝작업 내용

> 마이페이지에서 사용자의 선호운동을 선택하고 수정할 때 Zod와 @tanstack/react-form을 활용하여 폼 상태 관리 및 유효성 검사를 처리

- page.tsx에서 폼 상태를 관리하고, SelectionStep과 DetailStep 컴포넌트로 상태와 핸들러를 Props로 전달하는 방식 적용

close #236 